### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "19:00"
+  open-pull-requests-limit: 99


### PR DESCRIPTION
Adds a Dependabot config so this repo's dependencies are tracked, matching the org house style for its ecosystem (limit 99; cargo/uv weekly, npm/bundler daily at 19:00). Part of an org-wide sweep to ensure every active code repo has Dependabot coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)