### PR TITLE
ci: don't run Buildkite builds on dependabot branches

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 steps:
   - label: "Test"
+    branches: "!dependabot/*"
     command:
       - "bin/test"
     plugins:


### PR DESCRIPTION
Dependabot branches exist only to feed Renovate's consolidated PRs — they don't need their own CI run, and building every one adds significant Buildkite queue load.

This excludes `dependabot/*` branches from this repo's pipeline(s): unfiltered job steps gain `branches: "!dependabot/*"`, and `"!main"` steps become `"!main !dependabot/*"`. All other branches (main, topic/*, etc.) build exactly as before — only dependabot branches are skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)