### PR TITLE
ci: rust-ci -> bookworm-rust (retire the rust-ci shim).

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
       - "bin/test"
     plugins:
       - docker#v3.2.0:
-          image: "722349771793.dkr.ecr.ap-southeast-2.amazonaws.com/rust-ci:latest"
+          image: "722349771793.dkr.ecr.ap-southeast-2.amazonaws.com/bookworm-rust:latest"
           mount-ssh-agent: true
           environment:
             - "AWS_DEFAULT_REGION"


### PR DESCRIPTION
bookworm-rust is rust-ci's own base and carries the same tooling
(squirrel/zap/curtain, postgresql-client, awscli, libpq/libssl, curl, jq).
rust-ci's extra layer (old nightly, python3, gnuplot, diesel 1.4.1,
cargo-criterion) is unused here / self-installed (diesel via bin/install-diesel;
pinned nightly via rust-toolchain auto-install).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
