### PR TITLE
Migrate to trixie base images (codex#338, T5a rust)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
       - "bin/test"
     plugins:
       - docker#v3.2.0:
-          image: "722349771793.dkr.ecr.ap-southeast-2.amazonaws.com/bookworm-rust:latest"
+          image: "722349771793.dkr.ecr.ap-southeast-2.amazonaws.com/trixie-rust:latest"
           mount-ssh-agent: true
           environment:
             - "AWS_DEFAULT_REGION"


### PR DESCRIPTION
Rust leaf, bookworm→trixie. Suite-flip base refs + squirrel cache tags (bin/ + Dockerfile) + per-suite zap/kinesis tool fetches. Self-contained, no kraftwerk-runtime coupling. Chronicle-validated recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)