### PR TITLE
ci: apt-get update before apt install (codex#355 base cleanup)

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -7,7 +7,7 @@ cargo test --no-default-features
 
 cargo test --features "formats-geojson"
 
-apt-get install -y libgdal-dev
+apt-get update && apt-get install -y libgdal-dev
 cargo test --features "formats-gdal"
 
 cd ..


### PR DESCRIPTION
The trixie base images stopped shipping `/var/lib/apt/lists` (codex#355 cleans them in the base). Any `apt[-get] install` with no preceding `apt-get update` now fails to locate packages on its next build. Adds `apt-get update` ahead of the install(s). Found via a fleet-wide audit; test-infra only, green CI is the gate.