### PR TITLE
Clean workspace artifacts before every CI cargo build

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -2,6 +2,16 @@
 
 squirrel restore Cargo.lock target/debug ci.cache.sydney.kinesis.org
 
+# The restored target/ carries the mtimes of whichever agent built the
+# blob, while the checkout carries this agent's. cargo decides whether our
+# own crates need recompiling by comparing those two unrelated timelines,
+# so with Cargo.lock (the cache key) unchanged it can judge a stale
+# artifact fresh. Clean them so freshness is never consulted for our code;
+# the content-hashed third-party crates survive, which is the part of the
+# cache worth having.
+# https://github.com/kinesisptyltd/nexus/issues/1263
+cargo clean --workspace
+
 cd sulu-lib
 cargo test --no-default-features
 


### PR DESCRIPTION
Part of https://github.com/kinesisptyltd/nexus/issues/1263, same change as kinesisptyltd/oblivion#4879.

Adds `cargo clean --workspace` after the squirrel restore at every cache site in this repo, so each CI build compiles our crates from the source in that checkout. The restored `target/` and the checkout carry mtimes stamped on different machines, and cargo's freshness check for our own crates is that comparison, so with `Cargo.lock` unchanged it can judge a stale artifact fresh. In a test build that shows up as a compile error against source that is plainly there; in a release build it is silent, and the artifact ships under a commit whose code is not in it.

Sites changed:

- `bin/test`

## Testing

No test change, this is CI plumbing. The mechanism is already proven: kinesisptyltd/oblivion#4879 is merged, and prenup#118, kraftwerk-worker#230, burrow#21 and quarry#19 covered the Dockerfile, pipeline.yml, bin/ci and bin/test shapes between them. oblivion's `test` job ran 702s with the clean against 629-719s for the three previous main builds, so the extra rebuild sits inside normal run-to-run variance.

The real check here is this PR's own build.

cc @markhibberd @mattswoon